### PR TITLE
fix: make backend dual-stack ready

### DIFF
--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -63,4 +63,4 @@ fi
 cat /code/adventurelog.txt
 
 # Start gunicorn
-gunicorn main.wsgi:application --bind 0.0.0.0:8000 --timeout 120 --workers 2
+gunicorn main.wsgi:application --bind [::]:8000 --timeout 120 --workers 2


### PR DESCRIPTION
Currently the backend listens only on IPv4 in my setup all containers are dual-stack (IPv4 and IPv6) this breaks the connection between frontend and backend. Because the frontend container tries to connect to the IPv6 address of the backend container where the service doesn't listen on.

This PR makse the gunicon listener dual-stack ready.

Before
```bash
root@9abf6a659ba5:/code# ss -ltn
State             Recv-Q            Send-Q                       Local Address:Port                         Peer Address:Port            Process            
LISTEN            0                 511                                0.0.0.0:80                                0.0.0.0:*                                  
LISTEN            0                 4096                            127.0.0.11:40859                             0.0.0.0:*                                  
LISTEN            0                 2048                               0.0.0.0:8000                              0.0.0.0:*
root@9abf6a659ba5:/code# curl 127.0.0.1:8000 -v > /dev/null
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying 127.0.0.1:8000...
* Connected to 127.0.0.1 (127.0.0.1) port 8000 (#0)
> GET / HTTP/1.1
> Host: 127.0.0.1:8000
> User-Agent: curl/7.88.1
> Accept: */*
> 
< HTTP/1.1 200 OK
< Server: gunicorn
< Date: Tue, 14 Jan 2025 16:42:33 GMT
< Connection: close
< Content-Type: text/html; charset=utf-8
< X-Frame-Options: DENY
< Content-Length: 3978
< Vary: Cookie, origin
< 
{ [3978 bytes data]
100  3978  100  3978    0     0   9458      0 --:--:-- --:--:-- --:--:--  9471
* Closing connection 0
root@9abf6a659ba5:/code# curl [::1]:8000 -v > /dev/null
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying [::1]:8000...
* connect to ::1 port 8000 failed: Connection refused
* Failed to connect to ::1 port 8000 after 0 ms: Couldn't connect to server
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
* Closing connection 0
curl: (7) Failed to connect to ::1 port 8000 after 0 ms: Couldn't connect to server
```

After
```bash
root@9abf6a659ba5:/code# ss -ltn
State             Recv-Q            Send-Q                       Local Address:Port                         Peer Address:Port            Process            
LISTEN            0                 4096                            127.0.0.11:37997                             0.0.0.0:*                                  
LISTEN            0                 511                                0.0.0.0:80                                0.0.0.0:*                                  
LISTEN            0                 2048                                     *:8000                                    *:*                                  
root@9abf6a659ba5:/code# curl 127.0.0.1:8000 -v > /dev/null
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying 127.0.0.1:8000...
* Connected to 127.0.0.1 (127.0.0.1) port 8000 (#0)
> GET / HTTP/1.1
> Host: 127.0.0.1:8000
> User-Agent: curl/7.88.1
> Accept: */*
> 
< HTTP/1.1 200 OK
< Server: gunicorn
< Date: Tue, 14 Jan 2025 16:44:06 GMT
< Connection: close
< Content-Type: text/html; charset=utf-8
< X-Frame-Options: DENY
< Content-Length: 3978
< Vary: Cookie, origin
< 
{ [3978 bytes data]
100  3978  100  3978    0     0  10680      0 --:--:-- --:--:-- --:--:-- 10664
* Closing connection 0
root@9abf6a659ba5:/code# curl [::1]:8000 -v > /dev/null
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying [::1]:8000...
* Connected to ::1 (::1) port 8000 (#0)
> GET / HTTP/1.1
> Host: [::1]:8000
> User-Agent: curl/7.88.1
> Accept: */*
> 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0< HTTP/1.1 200 OK
< Server: gunicorn
< Date: Tue, 14 Jan 2025 16:44:10 GMT
< Connection: close
< Content-Type: text/html; charset=utf-8
< X-Frame-Options: DENY
< Content-Length: 3978
< Vary: Cookie, origin
< 
{ [3978 bytes data]
100  3978  100  3978    0     0  11430      0 --:--:-- --:--:-- --:--:-- 11431
* Closing connection 0
```