### PR TITLE
fix small python errors

### DIFF
--- a/backend/server/adventures/views.py
+++ b/backend/server/adventures/views.py
@@ -1236,7 +1236,7 @@ class ReverseGeocodeViewSet(viewsets.ViewSet):
                     return Response({"error": "Invalid response from geocoding service"}, status=400)
                 region = self.extractIsoCode(data)
                 if 'error' not in region:
-                    region = Region.objects.filter(id=region['id']).first()
+                    region = Region.objects.filter(id=region['region_id']).first()
                     visited_region = VisitedRegion.objects.filter(region=region, user_id=self.request.user).first()
                     if not visited_region:
                         visited_region = VisitedRegion(region=region, user_id=self.request.user)

--- a/backend/server/adventures/views.py
+++ b/backend/server/adventures/views.py
@@ -1163,6 +1163,7 @@ class ReverseGeocodeViewSet(viewsets.ViewSet):
         display_name = None
         country_code = None
         city = None
+        visited_city = None
 
         # town = None
         # city = None


### PR DESCRIPTION
When running the Visited Region update, I got some errors.

First error
```bash
adventurelog-backend  | Internal Server Error: /api/reverse-geocode/mark_visited_region/
adventurelog-backend  | Traceback (most recent call last):
adventurelog-backend  |   File "/usr/local/lib/python3.10/site-packages/django/core/handlers/exception.py", line 55, in inner
adventurelog-backend  |     response = get_response(request)
adventurelog-backend  |   File "/usr/local/lib/python3.10/site-packages/django/core/handlers/base.py", line 197, in _get_response
adventurelog-backend  |     response = wrapped_callback(request, *callback_args, **callback_kwargs)
adventurelog-backend  |   File "/usr/local/lib/python3.10/site-packages/django/views/decorators/csrf.py", line 65, in _view_wrapper
adventurelog-backend  |     return view_func(request, *args, **kwargs)
adventurelog-backend  |   File "/usr/local/lib/python3.10/site-packages/rest_framework/viewsets.py", line 124, in view
adventurelog-backend  |     return self.dispatch(request, *args, **kwargs)
adventurelog-backend  |   File "/usr/local/lib/python3.10/site-packages/rest_framework/views.py", line 509, in dispatch
adventurelog-backend  |     response = self.handle_exception(exc)
adventurelog-backend  |   File "/usr/local/lib/python3.10/site-packages/rest_framework/views.py", line 469, in handle_exception
adventurelog-backend  |     self.raise_uncaught_exception(exc)
adventurelog-backend  |   File "/usr/local/lib/python3.10/site-packages/rest_framework/views.py", line 480, in raise_uncaught_exception
adventurelog-backend  |     raise exc
adventurelog-backend  |   File "/usr/local/lib/python3.10/site-packages/rest_framework/views.py", line 506, in dispatch
adventurelog-backend  |     response = handler(request, *args, **kwargs)
adventurelog-backend  |   File "/code/adventures/views.py", line 1245, in mark_visited_region
adventurelog-backend  |     region = Region.objects.filter(id=region['id']).first()
adventurelog-backend  | KeyError: 'id'
```

After the fix of the first error for the region
```json
{'place_id': 250435910, 'licence': 'Data © OpenStreetMap contributors, ODbL 1.0. http://osm.org/copyright', 'osm_type': 'node', 'osm_id': 33728378, 'lat': '71.1699506', 'lon': '25.7858893', 'category': 'tourism', 'type': 'attraction', 'place_rank': 30, 'importance': 0.4880999334646339, 'addresstype': 'tourism', 'name': 'Nordkapp', 'display_name': 'Nordkapp, E 69, Nordkapp, Finnmark, Norge', 'address': {'tourism': 'Nordkapp', 'road': 'E 69', 'hamlet': 'Nordkapp', 'municipality': 'Nordkapp', 'county': 'Finnmark', 'ISO3166-2-lvl4': 'NO-56', 'country': 'Norge', 'country_code': 'no'}, 'boundingbox': ['71.1699006', '71.1700006', '25.7858393', '25.7859393']}
```

```bash
adventurelog-backend  | Internal Server Error: /api/reverse-geocode/mark_visited_region/
adventurelog-backend  | Traceback (most recent call last):
adventurelog-backend  |   File "/usr/local/lib/python3.10/site-packages/django/core/handlers/exception.py", line 55, in inner
adventurelog-backend  |     response = get_response(request)
adventurelog-backend  |   File "/usr/local/lib/python3.10/site-packages/django/core/handlers/base.py", line 197, in _get_response
adventurelog-backend  |     response = wrapped_callback(request, *callback_args, **callback_kwargs)
adventurelog-backend  |   File "/usr/local/lib/python3.10/site-packages/django/views/decorators/csrf.py", line 65, in _view_wrapper
adventurelog-backend  |     return view_func(request, *args, **kwargs)
adventurelog-backend  |   File "/usr/local/lib/python3.10/site-packages/rest_framework/viewsets.py", line 124, in view
adventurelog-backend  |     return self.dispatch(request, *args, **kwargs)
adventurelog-backend  |   File "/usr/local/lib/python3.10/site-packages/rest_framework/views.py", line 509, in dispatch
adventurelog-backend  |     response = self.handle_exception(exc)
adventurelog-backend  |   File "/usr/local/lib/python3.10/site-packages/rest_framework/views.py", line 469, in handle_exception
adventurelog-backend  |     self.raise_uncaught_exception(exc)
adventurelog-backend  |   File "/usr/local/lib/python3.10/site-packages/rest_framework/views.py", line 480, in raise_uncaught_exception
adventurelog-backend  |     raise exc
adventurelog-backend  |   File "/usr/local/lib/python3.10/site-packages/rest_framework/views.py", line 506, in dispatch
adventurelog-backend  |     response = handler(request, *args, **kwargs)
adventurelog-backend  |   File "/code/adventures/views.py", line 1242, in mark_visited_region
adventurelog-backend  |     region = self.extractIsoCode(data)
adventurelog-backend  |   File "/code/adventures/views.py", line 1204, in extractIsoCode
adventurelog-backend  |     if visited_city:
adventurelog-backend  | UnboundLocalError: local variable 'visited_city' referenced before assignment
```