### PR TITLE
fix: mark visited cities based on locations

### DIFF
--- a/backend/server/adventures/views.py
+++ b/backend/server/adventures/views.py
@@ -1221,6 +1221,8 @@ class ReverseGeocodeViewSet(viewsets.ViewSet):
         # searches through all of the users adventures, if the serialized data is_visited, is true, runs reverse geocode on the adventures and if a region is found, marks it as visited. Use the extractIsoCode function to get the region
         new_region_count = 0
         new_regions = {}
+        new_city_count = 0
+        new_cities = {}
         adventures = Adventure.objects.filter(user_id=self.request.user)
         serializer = AdventureSerializer(adventures, many=True)
         for adventure, serialized_adventure in zip(adventures, serializer.data):
@@ -1234,17 +1236,25 @@ class ReverseGeocodeViewSet(viewsets.ViewSet):
                     data = response.json()
                 except requests.exceptions.JSONDecodeError:
                     return Response({"error": "Invalid response from geocoding service"}, status=400)
-                region = self.extractIsoCode(data)
-                if 'error' not in region:
-                    region = Region.objects.filter(id=region['id']).first()
+                extracted_region = self.extractIsoCode(data)
+                if 'error' not in extracted_region:
+                    region = Region.objects.filter(id=extracted_region['region_id']).first()
                     visited_region = VisitedRegion.objects.filter(region=region, user_id=self.request.user).first()
                     if not visited_region:
                         visited_region = VisitedRegion(region=region, user_id=self.request.user)
                         visited_region.save()
                         new_region_count += 1
                         new_regions[region.id] = region.name
-        return Response({"new_regions": new_region_count, "regions": new_regions})
 
+                    if extracted_region['city_id'] is not None:
+                        city = City.objects.filter(id=extracted_region['city_id']).first()
+                        visited_city = VisitedCity.objects.filter(city=city, user_id=self.request.user).first()
+                        if not visited_city:
+                            visited_city = VisitedCity(city=city, user_id=self.request.user)
+                            visited_city.save()
+                            new_city_count += 1
+                            new_cities[city.id] = city.name
+        return Response({"new_regions": new_region_count, "regions": new_regions, "new_cities": new_city_count, "cities": new_cities})
 
 from django.http import HttpResponse
 from rest_framework import viewsets


### PR DESCRIPTION
Add the function to update visited cities over the `Update Visited Regions` button in the user settings.

Requires the fixes from #447 to work.