### PR TITLE
Update email.md

### DIFF
--- a/documentation/docs/configuration/email.md
+++ b/documentation/docs/configuration/email.md
@@ -13,14 +13,14 @@ environment:
 
 ```yaml
 environment:
-  - EMAIL_BACKEND='email'
-  - EMAIL_HOST='smtp.gmail.com'
-  - EMAIL_USE_TLS=False
+  - EMAIL_BACKEND=email
+  - EMAIL_HOST=smtp.gmail.com
+  - EMAIL_USE_TLS=True
   - EMAIL_PORT=587
-  - EMAIL_USE_SSL=True
-  - EMAIL_HOST_USER='user'
-  - EMAIL_HOST_PASSWORD='password'
-  - DEFAULT_FROM_EMAIL='user@example.com'
+  - EMAIL_USE_SSL=False
+  - EMAIL_HOST_USER=user
+  - EMAIL_HOST_PASSWORD=password
+  - DEFAULT_FROM_EMAIL=user@example.com
 ```
 
 ## Customizing Emails


### PR DESCRIPTION
Removing the single quotes allow SMTP to work -- it did not work otherwise. Also, [Google recommends TLS over SSL](https://support.google.com/a/answer/2520500?sjid=7564827219172741277-NA)