### PR TITLE
Modified translation to make it more natural und understandable

### DIFF
--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -1,6 +1,6 @@
 {
   "about": {
-    "about": "Um",
+    "about": "Über",
     "close": "Schließen",
     "license": "Lizenziert unter der GPL-3.0-Lizenz.",
     "message": "Hergestellt mit ❤️ in den Vereinigten Staaten.",
@@ -64,7 +64,7 @@
     "about": "Über AdventureLog",
     "adventures": "Abenteuer",
     "collections": "Sammlungen",
-    "discord": "Zwietracht",
+    "discord": "Discord",
     "documentation": "Dokumentation",
     "greeting": "Hallo",
     "login": "Login",


### PR DESCRIPTION
Modified two parts of the germand translation:
* "about" changed  to the more widely used "über" in the context it is presumably used
* "discord" from "Zwietracht" to "Discord" presumably the discord app is meant here. It has the same name in germany