### PR TITLE
Document deployment using Caddy

### DIFF
--- a/documentation/.vitepress/config.mts
+++ b/documentation/.vitepress/config.mts
@@ -80,6 +80,7 @@ export default defineConfig({
                 link: "/docs/install/nginx_proxy_manager",
               },
               { text: "Traefik", link: "/docs/install/traefik" },
+              { text: "Caddy", link: "/docs/install/caddy" },
             ],
           },
         ],

--- a/documentation/docs/install/caddy.md
+++ b/documentation/docs/install/caddy.md
@@ -1,0 +1,67 @@
+# Installation with Caddy
+
+Caddy is a modern HTTP reverse proxy. It automatically integrates with Let's Encrypt (or other certificate providers) to generate TLS certificates for your site.
+
+As an example, if you want to add Caddy to your Docker compose configuration, add the following service to your `docker-compose-ymö`:
+
+```yaml
+services:
+  caddy:
+    image: docker.io/library/caddy:2
+    container_name: adventurelog-caddy
+    restart: unless-stopped
+    cap_add:
+      - NET_ADMIN
+    ports:
+      - "80:80"
+      - "443:443"
+      - "443:443/udp"
+    volumes:
+      - ./caddy:/etc/caddy
+      - caddy_data:/data
+      - caddy_config:/config
+
+  web: ...
+  server: ...
+  db: ...
+
+volumes:
+  caddy_data:
+  caddy_config:
+```
+
+Since all ingress traffic to the AdventureLog containsers now travels through Caddy, we can also remove the external ports configuration from those containsers in the `docker-compose.yml`. Just delete this configuration:
+
+```yaml
+  web:
+    ports:
+      - "8016:80"
+…
+  server:
+    ports:
+      - "8015:3000"
+```
+
+That's it for the Docker compose changes. Of course, there are other methods to run Caddy which are equally valid.
+
+However, we also need to configure Caddy. For this, create a file `./caddy/Caddyfile` in which you configure the requests which are proxied to the frontend and backend respectively and what domain Caddy should request a certificate for:
+
+```
+adventurelog.example.com {
+
+  @frontend {
+    not path /media* /admin* /static* /accounts*
+  }
+  reverse_proxy @frontend web:3000
+
+  reverse_proxy server:80
+}
+```
+
+Once configured, you can start up the containsers:
+
+```bash
+docker compose up
+```
+
+Your AdventureLog should now be up and running.

--- a/documentation/docs/install/getting_started.md
+++ b/documentation/docs/install/getting_started.md
@@ -12,3 +12,4 @@ AdventureLog can be installed in a variety of ways. The following are the most c
 
 - [Nginx Proxy Manager](nginx_proxy_manager.md) 🛡
 - [Traefik](traefik.md) 🚀
+- [Caddy](caddy.md) 🔒


### PR DESCRIPTION
This patch adds documentation on how to run AdventureLog with Caddy as a reverse proxy.