### PR TITLE
Prevent unnecessary redirect when requesting users

### DIFF
--- a/frontend/src/lib/components/ShareModal.svelte
+++ b/frontend/src/lib/components/ShareModal.svelte
@@ -62,7 +62,7 @@
 		if (modal) {
 			modal.showModal();
 		}
-		let res = await fetch(`/auth/users/`);
+		let res = await fetch(`/auth/users`);
 		if (res.ok) {
 			let data = await res.json();
 			allUsers = data;

--- a/frontend/src/routes/users/+page.server.ts
+++ b/frontend/src/routes/users/+page.server.ts
@@ -9,7 +9,7 @@ export const load = (async (event) => {
 		return redirect(302, '/login');
 	}
 
-	const res = await fetch(`${serverEndpoint}/auth/users/`, {
+	const res = await fetch(`${serverEndpoint}/auth/users`, {
 		headers: {
 			Cookie: `sessionid=${sessionId}`
 		}


### PR DESCRIPTION
Opening the share dialog, the frontend is requesting `/auth/users/` which is always redirected to `/auth/users`. That's an unnecessary extra step:

```http
GET /auth/users/ HTTP/2

HTTP/2 308 
location: /auth/users


GET /auth/users HTTP/2

HTTP/2 200
```

This patch makes the front-end request `/auth/users` in the first place.