### PR TITLE
Prevent UI overlaps in lodging card

### DIFF
--- a/frontend/src/lib/components/LodgingCard.svelte
+++ b/frontend/src/lib/components/LodgingCard.svelte
@@ -96,20 +96,15 @@
 >
 	<div class="card-body space-y-4">
 		<!-- Title and Type -->
-		<div class="flex items-center justify-between">
-			<h2 class="card-title text-lg font-semibold truncate">{lodging.name}</h2>
-			<div class="flex items-center gap-2">
-				<div class="badge badge-secondary">
-					{$t(`lodging.${lodging.type}`) + ' ' + getLodgingIcon(lodging.type)}
-				</div>
-				<!-- {#if hotel.type == 'plane' && hotel.flight_number}
-					<div class="badge badge-neutral-200">{hotel.flight_number}</div>
-				{/if} -->
+		<h2 class="text-2xl font-semibold">{lodging.name}</h2>
+		<div>
+			<div class="badge badge-secondary">
+				{$t(`lodging.${lodging.type}`) + ' ' + getLodgingIcon(lodging.type)}
 			</div>
+			{#if unlinked}
+				<div class="badge badge-error">{$t('adventures.out_of_range')}</div>
+			{/if}
 		</div>
-		{#if unlinked}
-			<div class="badge badge-error">{$t('adventures.out_of_range')}</div>
-		{/if}
 
 		<!-- Location -->
 		<div class="space-y-2">


### PR DESCRIPTION
This patch prevents overlapping UI elements in the lodging card. It adjusts the UI to be more like the adventure cards when it comes to font size and element placing.

![Screenshot from 2025-04-07 01-28-45](https://github.com/user-attachments/assets/040fa597-1c6b-4ccd-b8d6-681515765886)

Fixes part of #539