### PR TITLE
Frontend OICD Login Fix

### DIFF
--- a/backend/server/users/views.py
+++ b/backend/server/users/views.py
@@ -165,7 +165,7 @@ class EnabledSocialProvidersView(APIView):
         providers = []
         for provider in social_providers:
             if provider.provider == 'openid_connect':
-                new_provider = f'oidc/{provider.client_id}'
+                new_provider = f'oidc/{provider.provider_id}'
             else:
                 new_provider = provider.provider
             providers.append({


### PR DESCRIPTION
This should solve https://github.com/seanmorley15/AdventureLog/issues/544
As stated, the issue is, that the login Url the backend is building is inserting the client_id, but the backend expects the provider_id. The oicd login is already working in the backend login page, as that seems to use the correct url.