### PR TITLE
Fix Python Syntax Error

### DIFF
--- a/backend/server/adventures/views/collection_view.py
+++ b/backend/server/adventures/views/collection_view.py
@@ -23,6 +23,7 @@ class CollectionViewSet(viewsets.ModelViewSet):
         order_direction = self.request.query_params.get('order_direction', 'asc')
 
         valid_order_by = ['name', 'updated_at', 'start_date']
+        if order_by not in valid_order_by:
             order_by = 'updated_at'
 
         if order_direction not in ['asc', 'desc']:


### PR DESCRIPTION
Commit 937c3c6a68e41356fd3de2aba826563951be1f91 introduced a Python syntax error, breaking the server. This fixes the issue by restoring the probably accidental removal of one line of code.