### PR TITLE
Show Note Preview on Card

### DIFF
--- a/frontend/src/lib/components/NoteCard.svelte
+++ b/frontend/src/lib/components/NoteCard.svelte
@@ -71,11 +71,28 @@
 		{#if unlinked}
 			<div class="badge badge-error">{$t('adventures.out_of_range')}</div>
 		{/if}
+		{#if note.content && note.content.length > 0}
+			<p class="line-clamp-6">
+				{note.content}
+			</p>
+		{/if}
 		{#if note.links && note.links.length > 0}
 			<p>
 				{note.links.length}
 				{note.links.length > 1 ? $t('adventures.links') : $t('adventures.link')}
 			</p>
+			<ul class="list-disc pl-6">
+				{#each note.links.slice(0, 3) as link}
+					<li>
+						<a class="link link-primary" href={link}>
+							{link.split('//')[1].split('/', 1)[0]}
+						</a>
+					</li>
+				{/each}
+				{#if note.links.length > 3}
+					<li>…</li>
+				{/if}
+			</ul>
 		{/if}
 		{#if note.date && note.date !== ''}
 			<div class="inline-flex items-center">


### PR DESCRIPTION
Often, you end up having short notes or even just a simple link and it is somewhat tedious to go into the details to retrieve the additional information.

This patch displays a preview of the note content and a maximum of three links on the notes card directly. This makes accessing information much faster.

This fixes #562.

![Screenshot from 2025-04-15 01-03-10](https://github.com/user-attachments/assets/50f8a793-1430-4d9e-8bb8-d00e0318f51c)
