### PR TITLE
Improve overlapping on navbar on mobile devices

### DIFF
--- a/frontend/src/lib/components/Navbar.svelte
+++ b/frontend/src/lib/components/Navbar.svelte
@@ -179,8 +179,9 @@
 				{/if}
 			</ul>
 		</div>
-		<a class="btn btn-ghost text-2xl font-bold tracking-normal" href="/">
-			AdventureLog <img src="/favicon.png" alt="Map Logo" class="w-10" />
+		<a class="btn btn-ghost p-0 text-2xl font-bold tracking-normal" href="/">
+			AdventureLog
+			<img src="/favicon.png" alt="Map Logo" class="w-10 md:inline hidden" />
 		</a>
 	</div>
 	<div class="navbar-center hidden lg:flex">
@@ -265,7 +266,7 @@
 			<Avatar user={data.user} />
 		{/if}
 		<div class="dropdown dropdown-bottom dropdown-end">
-			<div tabindex="0" role="button" class="btn m-1 ml-4">
+			<div tabindex="0" role="button" class="btn m-1 p-2">
 				<DotsHorizontal class="w-6 h-6" />
 			</div>
 			<!-- svelte-ignore a11y-no-noninteractive-tabindex -->

--- a/frontend/src/lib/components/Navbar.svelte
+++ b/frontend/src/lib/components/Navbar.svelte
@@ -180,8 +180,8 @@
 			</ul>
 		</div>
 		<a class="btn btn-ghost p-0 text-2xl font-bold tracking-normal" href="/">
-			AdventureLog
-			<img src="/favicon.png" alt="Map Logo" class="w-10 md:inline hidden" />
+			<span class="md:inline hidden">AdventureLog</span>
+			<img src="/favicon.png" alt="Map Logo" class="w-10" />
 		</a>
 	</div>
 	<div class="navbar-center hidden lg:flex">


### PR DESCRIPTION
This patch makes it less likely for elements of the navigation bar to overlap each other on mobile devices. It also makes spacing a bit more homogeneous.

The patch basically just adjust some spacing as and hides the map icon on mobile devices.

<img src=https://github.com/user-attachments/assets/74645485-60c6-4bd8-8a5a-7b06501e22d5 width=200 />
