### PR TITLE
Upgrade Node.js to Version 22

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,5 +1,5 @@
 # Use this image as the platform to build the app
-FROM node:18-alpine AS external-website
+FROM node:22-alpine AS external-website
 
 # A small line inside the image to show who made it
 LABEL Developers="Sean Morley"


### PR DESCRIPTION
This patch updates the Dockerfile to use Node.js 22 for running the frontend. Given that the security support of Node.js 18 ends in 6 days (30 Apr 2025), upgrading definitely makes sense.

Additionally, this also seems to fix the broken JSON generated by the recently upgrraded version of @sveltejs/kit, thus fixes #584.