### PR TITLE
Unify collection card width

### DIFF
--- a/frontend/src/lib/components/CollectionCard.svelte
+++ b/frontend/src/lib/components/CollectionCard.svelte
@@ -87,7 +87,7 @@
 {/if}
 
 <div
-	class="card min-w-max lg:w-96 md:w-80 sm:w-60 xs:w-40 bg-neutral text-neutral-content shadow-xl"
+	class="card w-full max-w-xs sm:max-w-sm md:max-w-md lg:max-w-md xl:max-w-md bg-neutral text-neutral-content shadow-xl overflow-hidden"
 >
 	<CardCarousel {adventures} />
 	<div class="card-body">


### PR DESCRIPTION
The width of collection cards can vary quite a bit. Additionally, the cards look different from the cards within a collection. It would be nice if the design would be more or leyy the same for all of them.

This patch adjusts the collection card design by adapting the classes from the cards within the collection (I literally just copied the classes from ChecklistCard). This is another step in making the user interface more homogeneous.

![Screenshot from 2025-04-27 15-29-18](https://github.com/user-attachments/assets/b1eedb33-db65-4604-b75a-467a529a1b49)

