### PR TITLE
Move hiding AdventureLog to first Tailwind breakpoint

### DIFF
--- a/frontend/src/lib/components/Navbar.svelte
+++ b/frontend/src/lib/components/Navbar.svelte
@@ -180,7 +180,7 @@
 			</ul>
 		</div>
 		<a class="btn btn-ghost p-0 text-2xl font-bold tracking-normal" href="/">
-			<span class="md:inline hidden">AdventureLog</span>
+			<span class="sm:inline hidden">AdventureLog</span>
 			<img src="/favicon.png" alt="Map Logo" class="w-10" />
 		</a>
 	</div>


### PR DESCRIPTION
This is a slight improvement to pull request #576. I noticed that on a tablet, the AdventureLog in the navigation bar would not render, even though there would be enpugh free space. This patch moves the breakpoint for hiding the text one step further towards smaller devices.