### PR TITLE
Remove Invisible MapMarker

### DIFF
--- a/frontend/src/lib/components/Navbar.svelte
+++ b/frontend/src/lib/components/Navbar.svelte
@@ -121,7 +121,6 @@
 			>
 				{#if data.user}
 					<li>
-						<MapMarker />
 						<button on:click={() => goto('/adventures')}>{$t('navbar.adventures')}</button>
 					</li>
 					<li>


### PR DESCRIPTION
This patch removes the map marker from the adventures list item of the main menu dropdown. It is not being rendered and given that all other elements do not have an icon, it is probably a remnant of old code and left by accident.


![Screenshot from 2025-04-27 15-58-50](https://github.com/user-attachments/assets/ab68a91d-7e4e-4bff-afc9-def7e082b0ae)
