### PR TITLE
Adjust main menu font size

### DIFF
--- a/frontend/src/lib/components/Navbar.svelte
+++ b/frontend/src/lib/components/Navbar.svelte
@@ -116,7 +116,7 @@
 			<!-- svelte-ignore a11y-no-noninteractive-tabindex -->
 			<ul
 				tabindex="0"
-				class="menu dropdown-content mt-3 z-[1] p-2 shadow bg-neutral text-neutral-content rounded-box gap-2 w-96"
+				class="menu dropdown-content mt-3 z-[1] p-2 shadow bg-neutral text-base text-neutral-content rounded-box gap-2 w-96"
 			>
 				{#if data.user}
 					<li>


### PR DESCRIPTION
This patch slightly adjusts the font size of list items in the main menu. I probably wouldn't mind making it even a bit bigger, but that's probably worth a separate discussion.

Reasons for this adjustment:

1. Don't use different font sizes in the same lement. While the buttons rendered at 14px, the search text rendered at 16px. They should have the same font-size.

2. The buttons were below the base text size controlled by Tailwind CSS. This means, it also puts the font size below the recommended font-size for mobile devices (Google/Apple guidelines). This patch puts them at the base level.

![Screenshot from 2025-04-27 15-58-05](https://github.com/user-attachments/assets/582f6ad1-da05-4f16-b80d-14be5f272a47)
