### PR TITLE
Full width map on mobile

### DIFF
--- a/frontend/src/routes/adventures/[id]/+page.svelte
+++ b/frontend/src/routes/adventures/[id]/+page.svelte
@@ -467,7 +467,7 @@
 								{/if}
 								<MapLibre
 									style="https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json"
-									class="flex items-center self-center justify-center aspect-[9/16] max-h-[70vh] sm:aspect-video sm:max-h-full w-10/12 rounded-lg"
+									class="flex items-center self-center justify-center aspect-[9/16] max-h-[70vh] sm:aspect-video sm:max-h-full w-full md:w-10/12 rounded-lg"
 									standardControls
 									center={{ lng: adventure.longitude || 0, lat: adventure.latitude || 0 }}
 									zoom={adventure.longitude ? 12 : 1}


### PR DESCRIPTION
This patch lets the map in the adventure details use the full screen width on mobile instead of having one sixth of the screen empty.

![Screenshot from 2025-04-27 17-47-28](https://github.com/user-attachments/assets/21e5a9a9-64cb-4b08-aad9-84ab6d53d890)
