### PR TITLE
update oidc button from client_id to provider_id

### DIFF
--- a/backend/server/users/views.py
+++ b/backend/server/users/views.py
@@ -165,7 +165,7 @@ class EnabledSocialProvidersView(APIView):
         providers = []
         for provider in social_providers:
             if provider.provider == 'openid_connect':
-                new_provider = f'oidc/{provider.client_id}'
+                new_provider = f'oidc/{provider.provider_id}'
             else:
                 new_provider = provider.provider
             providers.append({


### PR DESCRIPTION
oidc button takes me to a 500 error with this container log
`allauth.socialaccount.models.SocialApp.DoesNotExist`

Testing other column values in the table it seems that the provider_id is what actually works. I was able to log in using that instead of the provider's client_id