### PR TITLE
Change frontend_url example

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       - PUBLIC_URL=http://localhost:8016 # Match the outward port, used for the creation of image urls
       - CSRF_TRUSTED_ORIGINS=http://localhost:8016,http://localhost:8015 # Comma separated list of trusted origins for CSRF
       - DEBUG=False
-      - FRONTEND_URL=http://localhost:8015 # Used for email generation. This should be the url of the frontend
+      - FRONTEND_URL=http://adventurelog.yourdomain.com # Used for email generation. This should be the url of the frontend
     ports:
       - "8016:80"
     depends_on:


### PR DESCRIPTION
Since many people would be accessing AdventureLog from an actual domain via a reverse proxy (or a device name when using something like Tailscale) rather than localhost, I think it is a bit clearer to give such concrete example with a domain, without the port.