### PR TITLE
feat: allow user to override SESSION_COOKIE_DOMAIN with env variable

### DIFF
--- a/backend/server/main/settings.py
+++ b/backend/server/main/settings.py
@@ -168,6 +168,8 @@ else:
         # Fallback to the hostname if parsing fails
         SESSION_COOKIE_DOMAIN = hostname
 
+# Allow user to set their own SESSION_COOKIE_DOMAIN
+SESSION_COOKIE_DOMAIN = env('SESSION_COOKIE_DOMAIN', default=SESSION_COOKIE_DOMAIN)
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.7/howto/static-files/


### PR DESCRIPTION
Fixes #664

Allows user to set their own `SESSION_COOKIE_DOMAIN` when deploying for internal TLDs.

The default behaviour is preserved otherwise.