### PR TITLE
Remove breaking ownership check

### DIFF
--- a/backend/server/adventures/serializers.py
+++ b/backend/server/adventures/serializers.py
@@ -122,16 +122,6 @@ class AdventureSerializer(CustomModelSerializer):
         return [image for image in serializer.data if image is not None]
 
     def validate_collections(self, collections):
-        """Validate that collections belong to the same user"""
-        if not collections:
-            return collections
-            
-        user = self.context['request'].user
-        for collection in collections:
-            if collection.user_id != user:
-                raise serializers.ValidationError(
-                    f"Collection '{collection.name}' does not belong to the current user."
-                )
         return collections
 
     def validate_category(self, category_data):


### PR DESCRIPTION
Adventure: remove checking if adventure is contained in a collection not owned by the user.
This allows a user to add and modify adventures in a collection they have been shared.

related to #636

WARNING: as i am not the developer of this project I am unsure what the purpose of this check is.
I believe it was implemented to avoid users to modify other users' adventures (fair enough). However, checking the collections it is part of is not the right way. This limits collaboration.
Maybe rather check the owner of the actual adventure? but I would like to collaborate on these too, so that would still present an inconvenience.

I am unsure how to proceed, advice from the developer would be appreciated. @seanmorley15 

This does not (yet) fix the issue that a shared user cannot link to their own adventures, only create new ones:
Owner view of adding element to collection:
![owner view of adding element to collection](https://github.com/user-attachments/assets/2835a401-c819-4845-bc33-f4dad7231720)
Shared user view of adding element to collection
![shared user view of adding element to collection](https://github.com/user-attachments/assets/b85c4faa-0bc5-46eb-8800-c5d76b752339)
