### PR TITLE
Display transportation entries in selected time zone not UTC

### DIFF
--- a/backend/server/adventures/serializers.py
+++ b/backend/server/adventures/serializers.py
@@ -1,6 +1,7 @@
 from django.utils import timezone
 import os
 from .models import Adventure, AdventureImage, ChecklistItem, Collection, Note, Transportation, Checklist, Visit, Category, Attachment, Lodging
+from .utils.timezone_utils import format_datetime_in_selected_timezone
 from rest_framework import serializers
 from main.utils import CustomModelSerializer
 from users.serializers import CustomUserDetailsSerializer
@@ -254,6 +255,8 @@ class AdventureSerializer(CustomModelSerializer):
 
 class TransportationSerializer(CustomModelSerializer):
     distance = serializers.SerializerMethodField()
+    start_date_local = serializers.SerializerMethodField()
+    end_date_local = serializers.SerializerMethodField()
 
     class Meta:
         model = Transportation
@@ -262,7 +265,7 @@ class TransportationSerializer(CustomModelSerializer):
             'link', 'date', 'flight_number', 'from_location', 'to_location', 
             'is_public', 'collection', 'created_at', 'updated_at', 'end_date',
             'origin_latitude', 'origin_longitude', 'destination_latitude', 'destination_longitude',
-            'start_timezone', 'end_timezone', 'distance'  # ✅ Add distance here
+            'start_timezone', 'end_timezone', 'distance', 'start_date_local', 'end_date_local'  # ✅ Add distance here
         ]
         read_only_fields = ['id', 'created_at', 'updated_at', 'user_id', 'distance']
 
@@ -278,6 +281,12 @@ class TransportationSerializer(CustomModelSerializer):
             except ValueError:
                 return None
         return None
+    
+    def get_start_date_local(self, obj):
+        return format_datetime_in_selected_timezone(obj.date, obj.start_timezone)
+    
+    def get_end_date_local(self, obj):
+        return format_datetime_in_selected_timezone(obj.end_date, obj.end_timezone)
 
 class LodgingSerializer(CustomModelSerializer):
 

--- a/backend/server/adventures/utils/timezone_utils.py
+++ b/backend/server/adventures/utils/timezone_utils.py
@@ -1,0 +1,8 @@
+import pytz
+
+
+def format_datetime_in_selected_timezone(dt, user_tz):
+    if dt is None and user_tz is None:
+        return None
+    tz = pytz.timezone(user_tz)
+    return dt.astimezone(tz).isoformat()


### PR DESCRIPTION
Users expect transportation entries to reference either local user or the selected timezone not UTC. Updated transportation serializer to show times in their timezone instead of server UTC time.

Fixes #740 