### PR TITLE
Add dev docker-compose for hot reload and update WSL dev container docs (issue #944)

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,59 @@
+services:
+  web:
+    build: ./frontend/
+    image: ghcr.io/seanmorley15/adventurelog-frontend:latest
+    container_name: adventurelog-frontend
+    restart: unless-stopped
+    user: root
+    env_file: .env
+    environment:
+      - CI=true
+      - NODE_OPTIONS=--max-old-space-size=4096
+    ports:
+      - "${FRONTEND_PORT:-8015}:3000"
+    depends_on:
+      - server
+    volumes:
+      - ./frontend:/app
+      - pnpm_store:/pnpm-store
+    command: sh -c "mkdir -p /pnpm-store && chown -R node:node /pnpm-store && su node -c 'pnpm config set store-dir /pnpm-store && pnpm install --frozen-lockfile && pnpm exec vite dev --host 0.0.0.0 --port 3000 --strictPort'"
+
+  db:
+    image: postgis/postgis:16-3.5
+    container_name: adventurelog-db
+    restart: unless-stopped
+    env_file: .env
+    volumes:
+      - postgres_data:/var/lib/postgresql/data/
+
+  server:
+    build: ./backend/
+    image: ghcr.io/seanmorley15/adventurelog-backend:latest
+    container_name: adventurelog-backend
+    restart: unless-stopped
+    env_file: .env
+    environment:
+      - DJANGO_SUPERUSER_USERNAME=${DJANGO_ADMIN_USERNAME}
+      - DJANGO_SUPERUSER_PASSWORD=${DJANGO_ADMIN_PASSWORD}
+      - DJANGO_SUPERUSER_EMAIL=${DJANGO_ADMIN_EMAIL}
+    ports:
+      - "${BACKEND_PORT:-8016}:8000"
+    depends_on:
+      - db
+    volumes:
+      - ./backend/server:/code
+      - adventurelog_media:/code/media/
+    command: >
+      sh -c "memcached -u nobody -m 64 -p 11211 -d;
+      until pg_isready -h db -p 5432 >/dev/null 2>&1; do sleep 1; done;
+      python manage.py migrate --noinput;
+      python manage.py shell -c \"from worldtravel.models import Country; import sys; sys.exit(0 if Country.objects.exists() else 1)\" || python manage.py download-countries;
+      if [ -n \"$$DJANGO_SUPERUSER_USERNAME\" ] && [ -n \"$$DJANGO_SUPERUSER_PASSWORD\" ] && [ -n \"$$DJANGO_SUPERUSER_EMAIL\" ]; then
+        python manage.py createsuperuser --noinput --username \"$$DJANGO_SUPERUSER_USERNAME\" --email \"$$DJANGO_SUPERUSER_EMAIL\" || true;
+      fi;
+      python manage.py runserver 0.0.0.0:8000"
+
+volumes:
+  postgres_data:
+  adventurelog_media:
+  pnpm_store:

--- a/documentation/docs/install/dev_container_wsl.md
+++ b/documentation/docs/install/dev_container_wsl.md
@@ -12,6 +12,7 @@ Before starting, ensure you have the following installed:
   Download from: [https://www.docker.com/products/docker-desktop/](https://www.docker.com/products/docker-desktop/)
 
   > Docker Desktop must be configured to use **WSL 2**
+  > Make sure Docker Desktop is running before you start the steps below.
 
 * **WSL 2 with a Linux distribution installed**
   Ubuntu is recommended.
@@ -19,6 +20,7 @@ Before starting, ensure you have the following installed:
   ```bash
   wsl --install -d Ubuntu
   ```
+  Run this in **Windows PowerShell** (or **Windows Terminal**).
 
 * **Visual Studio Code**
   [https://code.visualstudio.com/](https://code.visualstudio.com/)
@@ -47,7 +49,7 @@ Before starting, ensure you have the following installed:
 
 ### 1. Clone the Repository (inside WSL)
 
-Open **Ubuntu (WSL)** and run:
+Open a WSL terminal (search for "WSL" in the Windows Start menu and open the WSL terminal), then run:
 
 ```bash
 cd ~
@@ -62,16 +64,16 @@ cd AdventureLog
 > git clone https://github.com/<your-username>/AdventureLog.git
 > ```
 
-### 2. Create the Development `.env` File
+### 2. Create the Development `.env` File (via WSL)
 
 ```bash
-cp .env.example .env
+cp .env.example .env && sed -i 's/^DEBUG=.*/DEBUG=True/' .env
 ```
 
-This creates the `.env` file required for the containers to start.
+This creates the `.env` file required for the containers to start and enables DEBUG for local development.
 
 > **NOTE**
-> The application will start without modifying `.env`. The default values provided in `.env.example` are sufficient for running the project.
+> The rest of the defaults in `.env.example` are sufficient for running the project.
 
 #### Environment Variables
 
@@ -103,16 +105,25 @@ VS Code will:
 * Install dependencies
 * Attach the editor to the running container
 
-The first build may take a few minutes.
+The first build usually takes around 30 seconds.
 
 ## Running the Application
 
 Once the Dev Container is running, the services are started using Docker Compose.
+Use the VS Code terminal (inside the Dev Container) for the commands below.
 
-If not started automatically, run:
+To start the app, enter the following command:
 
 ```bash
-docker compose up
+docker compose -f docker-compose.dev.yml up --build
+```
+
+Bringing the app up usually takes around 1-2 minutes.
+
+To fully reset the database and media volumes, run:
+
+```bash
+docker compose -f docker-compose.dev.yml down -v
 ```
 
 ## Accessing the App
@@ -123,7 +134,9 @@ docker compose up
 * **Backend (API)**
   [http://localhost:8016](http://localhost:8016)
 
-Admin credentials are taken from your `.env` file.
+Admin credentials are taken from your `.env` file. The `docker-compose.dev.yml` setup auto-creates a superuser on startup using those values so you can log in right away.
+It also checks whether the countries/flags data already exists before re-importing it, so the first build can take longer and subsequent `down`/`up` runs are faster.
+This dev setup can feel a bit slower because hot reload, dependency installs, and initial database bootstrapping all happen inside containers.
 
 ## Common Issues
 


### PR DESCRIPTION
## Summary
- Add `docker-compose.dev.yml` to run the frontend and backend in true dev mode (bind mounts + dev servers) so hot reload works.
- Update the WSL dev‑container guide to match the new dev‑compose workflow (DEBUG=True, proper commands, timing notes, superuser/flags bootstrapping).

## Why a dev compose file is needed
The base `docker-compose.yml` uses production‑style images and no code mounts. That setup doesn’t watch the local filesystem and doesn’t run Vite/Django dev servers, so hot reload cannot work. The dev compose file switches those services into dev‑server mode and mounts the local source so changes are picked up immediately.

---

## `docker-compose.dev.yml` line‑by‑line changes (in file order)

### `services.web`
1) `build: ./frontend/`  
   Enables a local dev image build for the frontend instead of only pulling the prebuilt image. This is necessary for running Vite’s dev server inside the container.

2) `user: root`  
   Allows the container to fix ownership of the PNPM store volume before dropping privileges to the `node` user.

3) `environment:`  
   - `CI=true`  
     Prevents PNPM from aborting in a non‑TTY container session.  
   - `NODE_OPTIONS=--max-old-space-size=4096`  
     Increases Node’s heap to avoid dev OOMs observed in the container.

4) `volumes:`  
   - `./frontend:/app`  
     Bind‑mounts local frontend code into the container so file changes trigger hot reload.  
   - `pnpm_store:/pnpm-store`  
     Moves PNPM’s store out of `/app` to avoid watcher loops/ELOOP errors and reduce filesystem churn.

5) `command: sh -c "mkdir -p /pnpm-store && chown -R node:node /pnpm-store && su node -c 'pnpm config set store-dir /pnpm-store && pnpm install --frozen-lockfile && pnpm exec vite dev --host 0.0.0.0 --port 3000 --strictPort'"`  
   - `mkdir -p /pnpm-store` ensures the store exists.  
   - `chown -R node:node /pnpm-store` fixes permissions for the `node` user.  
   - `su node -c ...` runs the rest as the non‑root `node` user.  
   - `pnpm config set store-dir /pnpm-store` keeps the store outside `/app` to avoid watcher recursion.  
   - `pnpm install --frozen-lockfile` installs dependencies deterministically.  
   - `pnpm exec vite dev --host 0.0.0.0 --port 3000 --strictPort` starts Vite’s dev server for hot reload and exposes it to the host.

### `services.db`
No functional changes beyond retaining the base DB setup. The DB section is unchanged in behavior from the base file.

### `services.server`
6) `build: ./backend/`  
   Builds the backend image locally so the container runs the Django dev server against local code.

7) `environment:`  
   - `DJANGO_SUPERUSER_USERNAME=${DJANGO_ADMIN_USERNAME}`  
   - `DJANGO_SUPERUSER_PASSWORD=${DJANGO_ADMIN_PASSWORD}`  
   - `DJANGO_SUPERUSER_EMAIL=${DJANGO_ADMIN_EMAIL}`  
   Passes admin credentials into the container so a dev superuser can be created automatically.

8) `ports: - "${BACKEND_PORT:-8016}:8000"`  
   Maps host port 8016 to **container port 8000** because the Django dev server listens on 8000 (not 80/Nginx like production).

9) `volumes:`  
   - `./backend/server:/code`  
     Bind‑mounts local backend code so Django’s autoreloader sees changes.  
   - `adventurelog_media:/code/media/`  
     Retains media persistence from the base compose.

10) `command: > sh -c "..."`
   - `memcached -u nobody -m 64 -p 11211 -d`  
     Starts the cache used by auth/rate‑limit logic so login works in dev.  
   - `until pg_isready -h db -p 5432 ...; do sleep 1; done;`  
     Waits for Postgres before running Django commands.  
   - `python manage.py migrate --noinput;`  
     Applies migrations automatically on startup so a fresh DB works without manual steps.  
   - `python manage.py shell -c "from worldtravel.models import Country; import sys; sys.exit(0 if Country.objects.exists() else 1)" || python manage.py download-countries;`  
     Seeds countries/flags only when the DB is empty to avoid re‑importing on every restart.  
   - `if [ -n "$DJANGO_SUPERUSER_USERNAME" ] ... createsuperuser ... || true; fi;`  
     Creates a dev admin account from `.env` values if it doesn’t already exist.  
   - `python manage.py runserver 0.0.0.0:8000`  
     Starts the Django dev server with autoreload enabled.

### `volumes`
11) `pnpm_store:`  
    New named volume used by the frontend to keep PNPM’s store outside `/app`.

---

## Docs
Updated the WSL dev‑container guide to align with the dev compose workflow, including:
- DEBUG=True creation step
- running the dev compose commands in the VS Code terminal
- startup timing expectations
- superuser and flags seeding notes

## Files changed
- Modified: `documentation/docs/install/dev_container_wsl.md`
- Added: `docker-compose.dev.yml`

---

Responding to the [#944 issue](https://github.com/seanmorley15/AdventureLog/issues/944)