### PR TITLE
fix: typo in backend success response

### DIFF
--- a/backend/server/templates/base.html
+++ b/backend/server/templates/base.html
@@ -175,7 +175,7 @@
           `<strong>API Response:</strong> ${data.status} ${data.statusText}<br/><strong>Content:</strong> ${data.responseText}`
         );
       };
-      const susccess_response = (data) => {
+      const success_response = (data) => {
         $(".api-response").html(
           `<strong>API Response:</strong> OK<br/><strong>Content:</strong> ${JSON.stringify(
             data,
@@ -190,7 +190,7 @@
           const form = $("form.ajax-post");
           $.post(form.attr("action"), form.serialize())
             .fail(error_response)
-            .done(susccess_response);
+            .done(success_response);
           return false;
         });
       });


### PR DESCRIPTION
Hi there,

Thanks for creating and maintaining AdventureLog! 💐

I am currently trying to package it for Nix and create a NixOS module for it in:
https://codeberg.org/totoroot/adventurelog-flake

I am still having some issues with backend requests, that I am not quite sure how to fix yet. Once I manage to get it working, I can provide an update.

However, while trouleshooting the backend requests, I stumbled across this typo and thought I'd open a PR for it.