### PR TITLE
Add Immich map link to location detail page

### DIFF
--- a/backend/server/users/serializers.py
+++ b/backend/server/users/serializers.py
@@ -97,11 +97,12 @@ class CustomUserDetailsSerializer(UserDetailsSerializer):
     """
 
     has_password = serializers.SerializerMethodField()
+    immich_server_url = serializers.SerializerMethodField()
 
     class Meta(UserDetailsSerializer.Meta):
         model = CustomUser
-        fields = UserDetailsSerializer.Meta.fields + ['has_password', 'disable_password']
-        read_only_fields = UserDetailsSerializer.Meta.read_only_fields + ('uuid', 'has_password', 'disable_password')
+        fields = UserDetailsSerializer.Meta.fields + ['has_password', 'disable_password', 'immich_server_url']
+        read_only_fields = UserDetailsSerializer.Meta.read_only_fields + ('uuid', 'has_password', 'disable_password', 'immich_server_url')
 
     @staticmethod
     def get_has_password(instance):
@@ -109,6 +110,12 @@ class CustomUserDetailsSerializer(UserDetailsSerializer):
         Computes whether the user has a usable password set.
         """
         return instance.has_usable_password()
+
+    @staticmethod
+    def get_immich_server_url(instance):
+        from integrations.models import ImmichIntegration
+        integration = ImmichIntegration.objects.filter(user=instance).first()
+        return integration.server_url if integration else None
 
     def to_representation(self, instance):
         """

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -19,6 +19,7 @@ export type User = {
 	disable_password: boolean;
 	measurement_system: 'metric' | 'imperial';
 	default_currency: string;
+	immich_server_url: string | null;
 };
 
 export type Collaborator = {

--- a/frontend/src/routes/locations/[id]/+page.svelte
+++ b/frontend/src/routes/locations/[id]/+page.svelte
@@ -676,7 +676,11 @@
 										{/if}
 
 										<!-- External Maps Links -->
-										<div class="grid grid-cols-3 gap-2 mb-3">
+										<div
+											class="grid gap-2 mb-3"
+											class:grid-cols-3={!immichServerUrl}
+											class:grid-cols-4={!!immichServerUrl}
+										>
 											<a
 												class="btn btn-sm btn-outline hover:btn-neutral"
 												href={`https://maps.apple.com/?q=${adventure.latitude},${adventure.longitude}`}
@@ -701,6 +705,16 @@
 											>
 												🗺️ OSM
 											</a>
+											{#if immichServerUrl}
+												<a
+													class="btn btn-sm btn-outline hover:btn-warning"
+													href={`${immichServerUrl.replace(/\/api\/?$/, '')}/map#16.64/${adventure.latitude}/${adventure.longitude}`}
+													target="_blank"
+													rel="noopener noreferrer"
+												>
+													📷 Immich
+												</a>
+											{/if}
 										</div>
 
 										<!-- Quick Copy Actions -->

--- a/frontend/src/routes/locations/[id]/+page.svelte
+++ b/frontend/src/routes/locations/[id]/+page.svelte
@@ -36,6 +36,7 @@
 	let measurementSystem = data.user?.measurement_system || 'metric';
 	console.log(data);
 
+	let immichServerUrl: string | null = data.user?.immich_server_url ?? null;
 	let adventure: AdditionalLocation;
 	let currentSlide = 0;
 


### PR DESCRIPTION
## Summary

- Adds a 📷 Immich button to the external maps section on location detail pages, alongside the existing Apple, Google, and OSM buttons
- The button links directly to Immich's map view at the location's coordinates (`/map#16.64/{lat}/{lon}`)
- The button only appears when the user has an Immich integration configured in Settings
- The Immich server URL is exposed via the existing user metadata endpoint (`/auth/user-metadata/`), so no additional API call is needed on the location page

Closes #1117

## Test plan

- [ ] Configure an Immich integration in Settings → Integrations
- [ ] Navigate to a location detail page that has coordinates set
- [ ] Verify the 📷 Immich button appears in the maps section alongside Apple, Google, and OSM
- [ ] Click the button and confirm it opens Immich's map view centred on the location
- [ ] Verify no Immich button appears for users without an Immich integration configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)