### PR TITLE
Add lightweight healthz endpoint

### DIFF
--- a/backend/server/main/urls.py
+++ b/backend/server/main/urls.py
@@ -2,7 +2,7 @@ from django.urls import include, re_path, path
 from django.contrib import admin
 from django.views.generic import RedirectView, TemplateView
 from users.views import IsRegistrationDisabled, PublicUserListView, PublicUserDetailView, UserMetadataView, UpdateUserMetadataView, EnabledSocialProvidersView, DisablePasswordAuthenticationView, APIKeyListCreateView, APIKeyDetailView, MobileQRCodeView
-from .views import get_csrf_token, get_public_url, serve_protected_media
+from .views import get_csrf_token, get_public_url, healthz, serve_protected_media
 from drf_yasg.views import get_schema_view
 from drf_yasg import openapi
 
@@ -13,6 +13,7 @@ schema_view = get_schema_view(
     )
 )
 urlpatterns = [
+    path('healthz/', healthz, name='healthz'),
     path('api/', include('adventures.urls')),
     path('api/', include('worldtravel.urls')),
     path("auth/", include("allauth.headless.urls")),

--- a/backend/server/main/views.py
+++ b/backend/server/main/views.py
@@ -13,6 +13,11 @@ def get_csrf_token(request):
 def get_public_url(request):
     return JsonResponse({'PUBLIC_URL': getenv('PUBLIC_URL')})
 
+
+def healthz(request):
+    return HttpResponse(status=204)
+
+
 protected_paths = ['images/', 'attachments/']
 
 def serve_protected_media(request, path):


### PR DESCRIPTION
Closes #1036.\n\nAdds an unauthenticated, lightweight `/healthz/` endpoint that returns `204 No Content`.\n\nThis gives container runtimes and orchestrators a clean liveness probe target without requiring authentication, database checks, or loading the full frontend/root page.\n\nUseful for Docker/Podman/Quadlet healthchecks, for example:\n\n```sh\npython3 -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:80/healthz/', timeout=3)"\n```\n\nValidated with:\n\n```sh\npython3 -m py_compile main/views.py main/urls.py\n```