### PR TITLE
Add lightweight healthz endpoint

### DIFF
--- a/backend/server/healthcheck.py
+++ b/backend/server/healthcheck.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""Container healthcheck for the AdventureLog backend."""
+
+from http.client import HTTPConnection
+from sys import exit
+
+
+HOST = "localhost"
+PORT = 8000
+PATH = "/healthz/"
+TIMEOUT_SECONDS = 5
+
+
+def main() -> int:
+    connection = HTTPConnection(HOST, PORT, timeout=TIMEOUT_SECONDS)
+    try:
+        connection.request("GET", PATH)
+        response = connection.getresponse()
+        return 0 if 200 <= response.status < 400 else 1
+    except Exception:
+        return 1
+    finally:
+        connection.close()
+
+
+if __name__ == "__main__":
+    exit(main())

--- a/backend/server/main/urls.py
+++ b/backend/server/main/urls.py
@@ -2,7 +2,7 @@ from django.urls import include, re_path, path
 from django.contrib import admin
 from django.views.generic import RedirectView, TemplateView
 from users.views import IsRegistrationDisabled, PublicUserListView, PublicUserDetailView, UserMetadataView, UpdateUserMetadataView, EnabledSocialProvidersView, DisablePasswordAuthenticationView, APIKeyListCreateView, APIKeyDetailView, MobileQRCodeView
-from .views import get_csrf_token, get_public_url, serve_protected_media
+from .views import get_csrf_token, get_public_url, healthz, serve_protected_media
 from drf_yasg.views import get_schema_view
 from drf_yasg import openapi
 
@@ -13,6 +13,7 @@ schema_view = get_schema_view(
     )
 )
 urlpatterns = [
+    path('healthz/', healthz, name='healthz'),
     path('api/', include('adventures.urls')),
     path('api/', include('worldtravel.urls')),
     path("auth/", include("allauth.headless.urls")),

--- a/backend/server/main/views.py
+++ b/backend/server/main/views.py
@@ -13,6 +13,11 @@ def get_csrf_token(request):
 def get_public_url(request):
     return JsonResponse({'PUBLIC_URL': getenv('PUBLIC_URL')})
 
+
+def healthz(request):
+    return HttpResponse(status=204)
+
+
 protected_paths = ['images/', 'attachments/']
 
 def serve_protected_media(request, path):

--- a/docker-compose-traefik.yaml
+++ b/docker-compose-traefik.yaml
@@ -71,6 +71,12 @@ services:
       - "traefik.http.routers.adventurelogserver.tls.certresolver=letsencrypt"
     depends_on:
       - db
+    healthcheck:
+      test: ["CMD", "python", "/code/healthcheck.py"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
 
 volumes:
   postgres-data:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -40,6 +40,12 @@ services:
       - "${BACKEND_PORT:-8016}:8000"
     depends_on:
       - db
+    healthcheck:
+      test: ["CMD", "python", "/code/healthcheck.py"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
     volumes:
       - ./backend/server:/code
       - adventurelog_media:/code/media/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,12 @@ services:
       - "${BACKEND_PORT:-8016}:80"
     depends_on:
       - db
+    healthcheck:
+      test: ["CMD", "python", "/code/healthcheck.py"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
     volumes:
       - adventurelog_media:/code/media/
 


### PR DESCRIPTION
Closes #1036.

Adds an unauthenticated, lightweight `/healthz/` endpoint that returns `204 No Content`.

This gives container runtimes and orchestrators a clean liveness probe target without requiring authentication, database checks, or loading the full frontend/root page.

Useful for Docker/Podman/Quadlet healthchecks, for example:

```sh
python3 -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:80/healthz/', timeout=3)"
```

Validated with:

```sh
python3 -m py_compile main/views.py main/urls.py
```
