### PR TITLE
make collection tabs wrap

### DIFF
--- a/frontend/src/routes/collections/+page.svelte
+++ b/frontend/src/routes/collections/+page.svelte
@@ -385,7 +385,7 @@
 			<!-- Header Section -->
 			<div class="sticky top-0 z-40 bg-base-100/80 backdrop-blur-lg border-b border-base-300">
 				<div class="container mx-auto px-6 py-4">
-					<div class="flex items-center justify-between">
+					<div class="flex flex-wrap gap-2 items-center justify-between">
 						<div class="flex items-center gap-4">
 							<button class="btn btn-ghost btn-square lg:hidden" on:click={toggleSidebar}>
 								<Filter class="w-5 h-5" />


### PR DESCRIPTION
## Related Issue

Closes #1109 

---

## Description

Allows the tabs to the right of the "My Collections" text to wrap to the next line to avoid non-accessable tabs on small screens.

---

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup
- [ ] Performance improvement
- [ ] Other (please describe)

---

## Checklist

Before submitting this PR, please confirm:

- [x] I have linked an existing issue
- [ ] The issue is **approved or marked as ready**
- [x] My changes follow the existing project structure and coding standards
- [x] I have tested the changes locally
- [x] Documentation has been updated if necessary

---

## Screenshots (if applicable)

[Screencast_20260603_224539.webm](https://github.com/user-attachments/assets/e29f5571-aa1f-4e10-a4a1-1c2e016aeb4d)

