### PR TITLE
Enhance cmd installer and documentation with compose-paths.sh integration

### DIFF
--- a/.github/workflows/installer-smoke-test.yml
+++ b/.github/workflows/installer-smoke-test.yml
@@ -52,6 +52,21 @@ jobs:
           bash scripts/validate-env.sh adventurelog-installer-test/.env
           rm -rf adventurelog-installer-test
 
+      - name: Curl-style flat lib bootstrap (no repo-relative paths)
+        run: |
+          # Mimic curl | bash: libs land in a flat temp dir with compose-paths.sh beside them
+          cache="$(mktemp -d)"
+          cp scripts/install/lib/*.sh "$cache/"
+          cp scripts/lib/compose-paths.sh "$cache/compose-paths.sh"
+          INSTALLER_LIB_DIR="$cache" bash -euo pipefail -c '
+            source "$INSTALLER_LIB_DIR/common.sh"
+            resolve_compose_settings
+            test "$COMPOSE_FILE" = "docker-compose.yml" -o "$COMPOSE_FILE" = "docker/docker-compose.yml"
+            test "$ENV_FILE" = ".env"
+            type resolve_compose_file >/dev/null
+          '
+          rm -rf "$cache"
+
   validate-env-aio:
     name: validate-env.sh Standard Deployment checks
     runs-on: ubuntu-latest

--- a/documentation/docs/install/quick_start.md
+++ b/documentation/docs/install/quick_start.md
@@ -59,6 +59,8 @@ Options include status, update, reconfigure, backup, restore, logs, restart, and
 Preview what the installer would do without making changes:
 
 ```bash
+curl -sSL https://get.adventurelog.app | bash -s -- --dry-run --force-install
+# or from a repo checkout:
 ADVENTURELOG_SKIP_GUM=1 bash install_adventurelog.sh --dry-run --force-install
 ```
 

--- a/install_adventurelog.sh
+++ b/install_adventurelog.sh
@@ -75,6 +75,7 @@ bootstrap_and_source_libs() {
 		local cache_dir
 		cache_dir="$(mktemp -d 2>/dev/null || echo "/tmp/adventurelog-installer-$$")"
 		mkdir -p "$cache_dir"
+		# Installer libs plus compose-paths.sh (normally under scripts/lib/).
 		local files=(
 			common.sh ui.sh tui.sh checks.sh download.sh deploy.sh
 			standard-config.sh advanced-config.sh manage.sh features.sh main.sh
@@ -87,6 +88,11 @@ bootstrap_and_source_libs() {
 				exit 1
 			}
 		done
+		curl -fsSL "${GITHUB_RAW}/scripts/lib/compose-paths.sh" -o "${cache_dir}/compose-paths.sh" || {
+			echo "ERROR: Failed to download scripts/lib/compose-paths.sh" >&2
+			echo "       Check ADVENTURELOG_REF=${ADVENTURELOG_REF} and your network connection." >&2
+			exit 1
+		}
 		INSTALLER_LIB_DIR="$cache_dir"
 	fi
 

--- a/scripts/install/lib/common.sh
+++ b/scripts/install/lib/common.sh
@@ -3,10 +3,48 @@
 # shellcheck disable=SC2034
 set -euo pipefail
 
-_COMPOSE_PATHS="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../lib" && pwd)/compose-paths.sh"
-if [[ -f "$_COMPOSE_PATHS" ]]; then
-	# shellcheck disable=SC1090
-	source "$_COMPOSE_PATHS"
+# compose-paths.sh lives in scripts/lib/ in the repo. Curl bootstrap copies it
+# next to the installer libs in a temp dir (INSTALLER_LIB_DIR).
+_source_compose_paths() {
+	local candidates=()
+	local here lib_dir candidate
+	here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+	candidates+=("${INSTALLER_LIB_DIR:-}/compose-paths.sh")
+	candidates+=("${here}/compose-paths.sh")
+	if lib_dir="$(cd "${here}/../../lib" 2>/dev/null && pwd)"; then
+		candidates+=("${lib_dir}/compose-paths.sh")
+	fi
+	candidates+=("${REPO_ROOT:-}/scripts/lib/compose-paths.sh")
+	for candidate in "${candidates[@]}"; do
+		if [[ -n "$candidate" && -f "$candidate" ]]; then
+			# shellcheck disable=SC1090
+			source "$candidate"
+			return 0
+		fi
+	done
+	return 1
+}
+
+# Minimal fallback when libs were bootstrapped into a flat temp dir without
+# compose-paths.sh (older installer entrypoints). Keep in sync with scripts/lib/compose-paths.sh.
+_install_compose_paths_fallback() {
+	COMPOSE_DIR="${COMPOSE_DIR:-docker}"
+	resolve_compose_file() {
+		local filename="$1"
+		if [[ -f "$filename" ]]; then
+			printf '%s\n' "$filename"
+		elif [[ -f "${COMPOSE_DIR}/${filename}" ]]; then
+			printf '%s\n' "${COMPOSE_DIR}/${filename}"
+		elif [[ -f "compose/${filename}" ]]; then
+			printf '%s\n' "compose/${filename}"
+		else
+			printf '%s\n' "${COMPOSE_DIR}/${filename}"
+		fi
+	}
+}
+
+if ! _source_compose_paths; then
+	_install_compose_paths_fallback
 fi
 
 APP_NAME="AdventureLog"

--- a/scripts/install/lib/download.sh
+++ b/scripts/install/lib/download.sh
@@ -56,6 +56,11 @@ copy_local_installer_libs() {
 	done
 }
 
+download_installer_entrypoint() {
+	download_file "${GITHUB_RAW}/install_adventurelog.sh" "install_adventurelog.sh"
+	chmod +x install_adventurelog.sh 2>/dev/null || true
+}
+
 download_standard_toolkit() {
 	log_info "Fetching Standard Deployment files"
 	mkdir -p docker scripts/lib
@@ -66,9 +71,14 @@ download_standard_toolkit() {
 	download_file "${GITHUB_RAW}/scripts/backup.sh" "scripts/backup.sh"
 	download_file "${GITHUB_RAW}/scripts/restore.sh" "scripts/restore.sh"
 	download_file "${GITHUB_RAW}/scripts/lib/compose-paths.sh" "scripts/lib/compose-paths.sh"
+	download_installer_entrypoint
 	chmod +x scripts/deploy.sh scripts/validate-env.sh scripts/backup.sh scripts/restore.sh 2>/dev/null || true
 	if [[ -d "$(dirname "${BASH_SOURCE[0]}")" ]]; then
 		copy_local_installer_libs "$(dirname "${BASH_SOURCE[0]}")" "scripts/install/lib"
+		# Curl bootstrap keeps compose-paths.sh beside the libs; copy it for offline re-runs.
+		if [[ -f "$(dirname "${BASH_SOURCE[0]}")/compose-paths.sh" ]]; then
+			cp "$(dirname "${BASH_SOURCE[0]}")/compose-paths.sh" "scripts/install/lib/compose-paths.sh" 2>/dev/null || true
+		fi
 	fi
 	log_success "Deployment toolkit ready"
 }
@@ -83,9 +93,13 @@ download_advanced_toolkit() {
 	download_file "${GITHUB_RAW}/scripts/backup.sh" "scripts/backup.sh"
 	download_file "${GITHUB_RAW}/scripts/restore.sh" "scripts/restore.sh"
 	download_file "${GITHUB_RAW}/scripts/lib/compose-paths.sh" "scripts/lib/compose-paths.sh"
+	download_installer_entrypoint
 	chmod +x scripts/deploy.sh scripts/validate-env.sh scripts/backup.sh scripts/restore.sh 2>/dev/null || true
 	if [[ -d "$(dirname "${BASH_SOURCE[0]}")" ]]; then
 		copy_local_installer_libs "$(dirname "${BASH_SOURCE[0]}")" "scripts/install/lib"
+		if [[ -f "$(dirname "${BASH_SOURCE[0]}")/compose-paths.sh" ]]; then
+			cp "$(dirname "${BASH_SOURCE[0]}")/compose-paths.sh" "scripts/install/lib/compose-paths.sh" 2>/dev/null || true
+		fi
 	fi
 	log_success "Deployment toolkit ready"
 }


### PR DESCRIPTION
- Added functionality to download and source compose-paths.sh during the installation process, improving path resolution for Docker Compose configurations.
- Updated the installer smoke test workflow to validate the new flat directory structure for libraries.
- Enhanced documentation to include curl command for dry-run installation, providing users with clearer instructions for setup.
- Refactored common library to support fallback mechanisms for compose-paths.sh sourcing, ensuring compatibility with various installation scenarios.