### PR TITLE
Update GitHub Actions workflows to ensure builds run correctly when c…

### DIFF
--- a/.github/workflows/_build-images.yml
+++ b/.github/workflows/_build-images.yml
@@ -78,7 +78,9 @@ jobs:
 
   build-frontend:
     needs: changes
-    if: ${{ !inputs.filter_paths || needs.changes.outputs.frontend == 'true' }}
+    # !cancelled() is required so builds still run when `changes` is skipped
+    # (filter_paths: false on release). Without it, GitHub skips dependents of skipped jobs.
+    if: ${{ !cancelled() && (!inputs.filter_paths || needs.changes.outputs.frontend == 'true') }}
     uses: ./.github/workflows/_build-image.yml
     with:
       context: .
@@ -91,7 +93,7 @@ jobs:
 
   build-backend:
     needs: changes
-    if: ${{ !inputs.filter_paths || needs.changes.outputs.backend == 'true' }}
+    if: ${{ !cancelled() && (!inputs.filter_paths || needs.changes.outputs.backend == 'true') }}
     uses: ./.github/workflows/_build-image.yml
     with:
       context: .
@@ -104,7 +106,7 @@ jobs:
 
   build-aio:
     needs: changes
-    if: ${{ !inputs.filter_paths || needs.changes.outputs.aio == 'true' }}
+    if: ${{ !cancelled() && (!inputs.filter_paths || needs.changes.outputs.aio == 'true') }}
     uses: ./.github/workflows/_build-image.yml
     with:
       context: .

--- a/.github/workflows/images-release.yml
+++ b/.github/workflows/images-release.yml
@@ -3,6 +3,12 @@ name: Build and push release images
 on:
   release:
     types: [released]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Image tag to push (e.g. v0.13.0)
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -13,7 +19,7 @@ jobs:
   build:
     uses: ./.github/workflows/_build-images.yml
     with:
-      tag: ${{ github.event.release.tag_name }}
+      tag: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.event.release.tag_name }}
       filter_paths: false
       include_latest_tag: true
     secrets: inherit


### PR DESCRIPTION
…hanges are skipped

- Added `!cancelled()` condition to the `if` statements in `_build-images.yml` for frontend, backend, and aio jobs to ensure they execute even when the `changes` job is skipped.
- Modified `images-release.yml` to allow manual triggering with a specified image tag, enhancing flexibility for image releases.
